### PR TITLE
파이프라인 추가: fdee31a1-709e-48d1-b0eb-bf2b20e311c4

### DIFF
--- a/dags/fdee31a1-709e-48d1-b0eb-bf2b20e311c4.py
+++ b/dags/fdee31a1-709e-48d1-b0eb-bf2b20e311c4.py
@@ -1,0 +1,1 @@
+# pipeline: fdee31a1-709e-48d1-b0eb-bf2b20e311c4


### PR DESCRIPTION

다음 파이프라인을 추가합니다
- 파이프라인 ID: fdee31a1-709e-48d1-b0eb-bf2b20e311c4
- 파이프라인 이름: default
- 파이프라인 설명: default
- 파이프라인 이미지: default
- 소스 데이터: default
- SQL: default
- 타겟 데이터: default

운영 HUE 에서 위의 SQL을 수행한 결과를 첨부해주세요 @요청자
- 스크린샷:

파이프라인 정보를 확인해주세요 @nyx.domi @geek.05 @gen.tleman @steve.22
[] 파이프라인 정보가 올바른가요?
[] 파이프라인의 리소스 사용이 적정한가요?
[] 파이프라인 스케줄 설정이 적정한가요?
